### PR TITLE
Partner display name with reference. eg Demo User (25874589)

### DIFF
--- a/care_partner_ssmmid/__init__.py
+++ b/care_partner_ssmmid/__init__.py
@@ -1,0 +1,2 @@
+
+from . import models

--- a/care_partner_ssmmid/__manifest__.py
+++ b/care_partner_ssmmid/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    'name': "Care : Ref in Partner name",
+    'summary': "Partner display name will show name (reference)",
+    'description':
+        """
+        The partner display name is shown as Name (Reference). 
+        When a partner is created, a unique SSMM ID is generated in CareERP and stored in the reference field. 
+        If a reference ID is available, it will be displayed along with the partner name throughout the system. 
+        The display_name functionality has been customized accordingly.
+        """,
+    'author': "radorp pvt ltd",
+    'website': "https://radorp.com/",
+    'license': "LGPL-3",
+    'category': "Accounting",
+    'version': "19.0.1.0.0",
+    'depends': ['base'],
+
+    'data': [],
+}

--- a/care_partner_ssmmid/models/__init__.py
+++ b/care_partner_ssmmid/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/care_partner_ssmmid/models/res_partner.py
+++ b/care_partner_ssmmid/models/res_partner.py
@@ -1,0 +1,13 @@
+from odoo import models, fields, api
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.depends('name', 'ref')
+    def _compute_display_name(self):
+        for partner in self:
+            if partner.ref:
+                partner.display_name = f"{partner.name} ({partner.ref})"
+            else:
+                partner.display_name = partner.name


### PR DESCRIPTION
The partner display name is shown as Name (Reference). When a partner is created, a unique SSMM ID is generated in CareERP and stored in the reference field. If a reference ID is available, it will be displayed along with the partner name throughout the system. The display_name functionality has been customized accordingly.